### PR TITLE
Update and apply data checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Chess Activity Flatpak
+
+This is a Sugar front end to the gnuchess program. 
+To know more refer https://github.com/sugarlabs/sugarchess
+
+## How To Build
+
+```
+git clone https://github.com/flathub/org.sugarlabs.Chess.git
+cd org.sugarlabs.Chess
+flatpak -y --user install org.gnome.{Platform,Sdk}//44
+flatpak-builder --user --force-clean --install build org.sugarlabs.Chess.json
+```
+
+## Check For Updates
+
+Install the flatpak external data checker
+```
+flatpak --user install org.flathub.flatpak-external-data-checker
+```
+
+Now to update every single module to the latest stable version use
+```
+cd org.sugarlabs.Chess
+flatpak run --filesystem=$PWD org.flathub.flatpak-external-data-checker org.sugarlabs.Chess.json
+```

--- a/chess-fix-clip.patch
+++ b/chess-fix-clip.patch
@@ -1,0 +1,20 @@
+diff --git a/GNUChessActivity.py b/GNUChessActivity.py
+index d19fb9f..e7efe47 100644
+--- a/GNUChessActivity.py
++++ b/GNUChessActivity.py
+@@ -489,12 +489,12 @@ class GNUChessActivity(activity.Activity):
+         return
+ 
+     def _copy_cb(self, *args):
+-        clipboard = Gtk.Clipboard()
+-        clipboard.set_text(self.tag_pairs() + self._gnuchess.copy_game())
++        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
++        clipboard.set_text(self.tag_pairs() + self._gnuchess.copy_game(), -1)
+ 
+     def _paste_cb(self, *args):
+         ''' Pasting '''
+-        clipboard = Gtk.Clipboard()
++        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+         move_list = self._parse_move_list(clipboard.wait_for_text())
+         if move_list is not None:
+             self._gnuchess.restore_game(move_list)

--- a/org.sugarlabs.Chess.json
+++ b/org.sugarlabs.Chess.json
@@ -32,7 +32,14 @@
                 {
                     "type": "archive",
                     "url": "http://ftp.gnu.org/gnu/chess/gnuchess-5.08.tar.gz",
-                    "sha256": "c4e49e0dec210f5d131a02ff89588b482787cd702a08456791ba9100b4c6ffc0"
+                    "sha256": "c4e49e0dec210f5d131a02ff89588b482787cd702a08456791ba9100b4c6ffc0",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "http://ftp.gnu.org/gnu/chess/",
+                        "versions": {"<": "6.0.0"},
+                        "pattern": "<a href=\"(gnuchess-([\\d\\.]+\\d).tar.gz)\">"
+
+                    }
                 }
             ]
         },

--- a/org.sugarlabs.Chess.json
+++ b/org.sugarlabs.Chess.json
@@ -46,11 +46,20 @@
                 {
                     "type": "git",
                     "url": "https://github.com/sugarlabs/sugarchess.git",
-                    "commit": "772d1ab8ea5b613d02818649ff0a8e86d066c145"
+                    "tag": "v18",
+                    "commit": "4501293b6b897d3267f0840a9801131d09572619",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 },
                 {
                     "type": "patch",
                     "path": "chess-port.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "chess-fix-clip.patch"
                 },
                 {
                     "type": "patch",

--- a/org.sugarlabs.Chess.json
+++ b/org.sugarlabs.Chess.json
@@ -1,9 +1,9 @@
 {
     "app-id": "org.sugarlabs.Chess",
     "base": "org.sugarlabs.BaseApp",
-    "base-version": "22.06",
+    "base-version": "23.06",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
     "separate-locales": false,
     "command": "sugarapp",


### PR DESCRIPTION
I have constrained gnuchess version < 6.0.0 because of weird bugs if we update that.. like the pieces don't appear at all in 6.2.9 and black doesn't move its turn in 6.0.0 even though all pieces appear.